### PR TITLE
add ringcentral-web-widget folder to support old github page uri

### DIFF
--- a/ringcentral-web-widget/adapter.js
+++ b/ringcentral-web-widget/adapter.js
@@ -1,17 +1,17 @@
 (function() {
   console.warn('this uri is deprecated. Please stop use it soon before the feature is completely removed. Please use new uri: https://ringcentral.github.io/ringcentral-embeddable-voice/adapter.js');
-  var currentScipt = document.currentScript;
-  if (!currentScipt) {
-    currentScipt = document.querySelector('script[src*="adapter.js"]');
+  var currentScript = document.currentScript;
+  if (!currentScript) {
+    currentScript = document.querySelector('script[src*="adapter.js"]');
   }
-  if (currentScipt && currentScipt.src) {
-    currentScipt = currentScipt.src;
-    currentScipt = currentScipt.replace('ringcentral-web-widget', 'ringcentral-embeddable-voice');
+  if (currentScript && currentScript.src) {
+    currentScript = currentScript.src;
+    currentScript = currentScript.replace('ringcentral-web-widget', 'ringcentral-embeddable-voice');
   } else {
-    currentScipt = "https://ringcentral.github.io/ringcentral-embeddable-voice/adapter.js";
+    currentScript = "https://ringcentral.github.io/ringcentral-embeddable-voice/adapter.js";
   }
   var rc_s = document.createElement("script");
-  rc_s.src = currentScipt;
+  rc_s.src = currentScript;
   var rc_s0 = document.getElementsByTagName("script")[0];
   rc_s0.parentNode.insertBefore(rc_s, rc_s0);
 })();

--- a/ringcentral-web-widget/adapter.js
+++ b/ringcentral-web-widget/adapter.js
@@ -1,0 +1,17 @@
+(function() {
+  console.warn('this uri is deprecated. Please stop use it soon before the feature is completely removed. Please use new uri: https://ringcentral.github.io/ringcentral-embeddable-voice/adapter.js');
+  var currentScipt = document.currentScript;
+  if (!currentScipt) {
+    currentScipt = document.querySelector('script[src*="adapter.js"]');
+  }
+  if (currentScipt && currentScipt.src) {
+    currentScipt = currentScipt.src;
+    currentScipt = currentScipt.replace('ringcentral-web-widget', 'ringcentral-embeddable-voice');
+  } else {
+    currentScipt = "https://ringcentral.github.io/ringcentral-embeddable-voice/adapter.js";
+  }
+  var rc_s = document.createElement("script");
+  rc_s.src = currentScipt;
+  var rc_s0 = document.getElementsByTagName("script")[0];
+  rc_s0.parentNode.insertBefore(rc_s, rc_s0);
+})();

--- a/ringcentral-web-widget/app.html
+++ b/ringcentral-web-widget/app.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html data-destination="https://ringcentral.github.io/ringcentral-embeddable-voice/app.html">
+  <head>
+    <noscript><meta id="redirect" http-equiv="refresh" content="0; url=https://ringcentral.github.io/ringcentral-embeddable-voice/app.html"></noscript>
+  </head>
+
+  <body>
+    This page has moved. Redirecting...
+  <script>
+  	console.warn('this uri is deprecated. Please stop use it soon before the feature is completely removed. Please use new uri: https://ringcentral.github.io/ringcentral-embeddable-voice/app.html');
+    var destination = document.documentElement.getAttribute('data-destination');
+    window.location.href = destination + (window.location.search || '') + (window.location.hash || '');
+  </script>
+  </body>
+</html>

--- a/ringcentral-web-widget/index.html
+++ b/ringcentral-web-widget/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf8">
+  <meta http-equiv="refresh" content="0; url=https://ringcentral.github.io/ringcentral-embeddable-voice/">
+  <link rel="canonical" href="https://ringcentral.github.io/ringcentral-embeddable-voice/">
+  <title>This page has moved</title>
+</head>
+<body>
+  <p>This page has moved. Redirecting you to <a href="https://ringcentral.github.io/ringcentral-embeddable-voice/">https://ringcentral.github.io/ringcentral-embeddable-voice/</a>&hellip;</p>
+</body>
+</html>

--- a/ringcentral-web-widget/proxy.html
+++ b/ringcentral-web-widget/proxy.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html data-destination="https://ringcentral.github.io/ringcentral-embeddable-voice/proxy.html">
+  <head>
+    <noscript><meta id="redirect" http-equiv="refresh" content="0; url=https://ringcentral.github.io/ringcentral-embeddable-voice/proxy.html"></noscript>
+  </head>
+
+  <body>
+    Redirecting...
+  <script>
+    console.warn('this uri is deprecated. Please stop use it soon before the feature is completely removed. Please use new uri: https://ringcentral.github.io/ringcentral-embeddable-voice/proxy.html');
+    var destination = document.documentElement.getAttribute('data-destination');
+    window.location.href = destination + (window.location.search || '') + (window.location.hash || '');
+  </script>
+  </body>
+</html>

--- a/ringcentral-web-widget/redirect.html
+++ b/ringcentral-web-widget/redirect.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html data-destination="https://ringcentral.github.io/ringcentral-embeddable-voice/redirect.html">
+  <head>
+    <noscript><meta id="redirect" http-equiv="refresh" content="0; url=https://ringcentral.github.io/ringcentral-embeddable-voice/redirect.html"></noscript>
+  </head>
+
+  <body>
+    Redirecting...
+  <script>
+    console.warn('this uri is deprecated. Please stop use it soon before the feature is completely removed. Please use new uri: https://ringcentral.github.io/ringcentral-embeddable-voice/redirect.html');
+    var destination = document.documentElement.getAttribute('data-destination');
+    window.location.href = destination + (window.location.search || '') + (window.location.hash || '');
+  </script>
+  </body>
+</html>


### PR DESCRIPTION
This PR is to keep `ringcentral-embeddable-voice` app backward compatibility after we rename it from `ringcentral-web-widget`.

We will rename `ringcentral-web-widget` repo to `ringcentral-embeddable-voice`.
So the repo github page uri will change from `https://ringcentral.github.io/ringcentral-web-widget` to `https://ringcentral.github.io/ringcentral-embeddable-voice`. But github page can't auto redirect. So create `ringcentral-web-widget` folder in this github page repo to support old repo github page uri.

When repo is renamed, it will rename following uri to new uri:
  * https://ringcentral.github.io/ringcentral-web-widget  => https://ringcentral.github.io/ringcentral-embeddable-voice
  * https://ringcentral.github.io/ringcentral-web-widget/app.html  => https://ringcentral.github.io/ringcentral-embeddable-voice/app.html

When developer use old adapter.js to load `ringcentral-embeddable-voice`, it will load `https://ringcentral.github.io/ringcentral-embeddable-voice/adapter.js`
